### PR TITLE
Require maven package due to old xmvn in COPR

### DIFF
--- a/ovirt-engine-extension-aaa-jdbc.spec.in
+++ b/ovirt-engine-extension-aaa-jdbc.spec.in
@@ -35,6 +35,9 @@ BuildRequires:	mvn(org.apache.commons:commons-lang)
 BuildRequires:	mvn(org.ovirt.engine.api:ovirt-engine-extensions-api)
 BuildRequires:	mvn(org.slf4j:slf4j-jdk14)
 
+# Required because of old xmvn version in COPR
+BuildRequires: maven
+
 Requires:	java-11-openjdk-headless >= 1:11.0.0
 Requires:	javapackages-filesystem
 Requires:	apache-commons-codec


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
