### PR TITLE
Update dependency to Lang3 in module.xml

### DIFF
--- a/packaging/modules/org/ovirt/engine/extension/aaa/jdbc/main/module.xml
+++ b/packaging/modules/org/ovirt/engine/extension/aaa/jdbc/main/module.xml
@@ -10,7 +10,7 @@
         <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="org.apache.commons.codec"/>
-        <module name="org.apache.commons.lang"/>
+        <module name="org.apache.commons.lang3"/>
         <module name="org.ovirt.engine.api.ovirt-engine-extensions-api"/>
         <module name="org.postgresql"/>
         <module name="org.slf4j"/>


### PR DESCRIPTION
Latest changes to ovirt-engine-extension-aaa-jdbc has changed dependencies, now org.apache.commons.lang3 instead of org.apache.commons.lang: 552ee0d

This change is not reflected in the corresponding module.xml, breaking the execution engine-setup playbook. Correctly referencing the now used org.apache.commons.lang3 module fixes the process.